### PR TITLE
Refactor Roster search methods

### DIFF
--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -457,10 +457,18 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
         }
     }
     
+    /** 
+     * Internal interface works with #findMatchingEntries
+     * to provide a common search-match-return capability.
+     */
     private interface RosterComparator {
         public boolean check(RosterEntry r);
     }
     
+    /** 
+     * Internal method works with #RosterComparator
+     * to provide a common search-match-return capability.
+     */
     private List<RosterEntry> findMatchingEntries(RosterComparator c) {
         List<RosterEntry> l = new ArrayList<>();
         for (RosterEntry r : _list) {
@@ -473,7 +481,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     
     /**
      * Get a List of {@link RosterEntry} objects in Roster matching some
-     * information. The list may have null contents if there are no matches.
+     * information. The list will be empty if there are no matches.
      *
      * @param roadName
      * @param roadNumber
@@ -485,7 +493,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
      * @param id
      * @return List or matching RosterEntries or an empty List
      */
-    public List<RosterEntry> getEntriesMatchingCriteria(String roadName, String roadNumber, String dccAddress,
+    public @Nonnull List<RosterEntry> getEntriesMatchingCriteria(String roadName, String roadNumber, String dccAddress,
             String mfg, String decoderMfgID, String decoderVersionID, String id, String group) {
         return findMatchingEntries(
             (RosterEntry r) -> { 
@@ -498,7 +506,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
 
     /**
      * Get a List of {@link RosterEntry} objects in Roster matching some
-     * information. The list may have null contents if there are no matches.
+     * information. The list will be empty if there are no matches.
      *
      * This method calls {@link #getEntriesMatchingCriteria(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String)
      * }
@@ -516,7 +524,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
      * java.lang.String, java.lang.String, java.lang.String, java.lang.String,
      * java.lang.String, java.lang.String)
      */
-    public List<RosterEntry> matchingList(String roadName, String roadNumber, String dccAddress,
+    public @Nonnull List<RosterEntry> matchingList(String roadName, String roadNumber, String dccAddress,
             String mfg, String decoderMfgID, String decoderVersionID, String id) {
         return this.getEntriesMatchingCriteria(roadName, roadNumber, dccAddress, mfg, decoderMfgID, decoderVersionID, id, null);
     }
@@ -524,7 +532,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     /**
      * Check if an entry is consistent with specific properties.
      * <P>
-     * A null String entry always matches. Strings are used for convenience in
+     * A null String argument always matches. Strings are used for convenience in
      * GUI building.
      *
      * @param i
@@ -547,7 +555,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     /**
      * Check if an entry is consistent with specific properties.
      * <P>
-     * A null String entry always matches. Strings are used for convenience in
+     * A null String argument always matches. Strings are used for convenience in
      * GUI building.
      *
      * @param list
@@ -574,7 +582,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     /**
      * Check if an entry is consistent with specific properties.
      * <P>
-     * A null String entry always matches. Strings are used for convenience in
+     * A null String argument always matches. Strings are used for convenience in
      * GUI building.
      *
      * @param r

--- a/java/test/jmri/jmrit/roster/RosterTest.java
+++ b/java/test/jmri/jmrit/roster/RosterTest.java
@@ -73,6 +73,29 @@ public class RosterTest extends TestCase {
         Assert.assertEquals("search OK ", true, r.checkEntry(0, null, "123", null, null, null, null, null, null));
     }
 
+    public void testGetByDccAddress() {
+        Roster r = new Roster();
+        RosterEntry e = new RosterEntry("file name Bob");
+        e.setDccAddress("456");
+        r.addEntry(e);
+        Assert.assertEquals("search not OK ", false, r.checkEntry(0, null, null, "123", null, null, null, null, null));
+        Assert.assertEquals("search OK ", true, r.checkEntry(0, null, null, "456", null, null, null, null, null));
+        
+        List<RosterEntry> l;
+
+        l = r.matchingList(null, null, "123", null, null, null, null);
+        Assert.assertEquals("match 123", 0, l.size());
+
+        l = r.matchingList(null, null, "456", null, null, null, null);
+        Assert.assertEquals("match 456", 1, l.size());
+        
+        l = r.getEntriesByDccAddress("123");
+        Assert.assertEquals("address 123", 0, l.size());
+
+        l = r.getEntriesByDccAddress("456");
+        Assert.assertEquals("address 456", 1, l.size());
+    }
+
     public void testSearchList() {
         Roster r = new Roster();
         RosterEntry e;


### PR DESCRIPTION
Separate the "index over entries" and "compare to search" parts of searching the roster for matching entries (uses Java completions)

Add a new comparison checkEntry() method that checks a specific RosterEntry
    Refactor the checkEntry that takes an index to use new one-RosterEntry form
    
Refactor getEntriesMatchingCriteria to use new common forms

Refactor getEntriesByDccAddress to use new common form

Add some @Nonnull annotations

Note: Some of the searches return null if none, some return an empty list.  This should be rationalized some day.
